### PR TITLE
build v1p1beta1 google speech 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,8 @@ freeswitch_log_conf_template: ../templates/logfile.conf.xml
 build_with_extra: false
 
 grpc_version: v1.24.2
+googleapis_version: v1p1beta1-speech
+
 aws_sdk_version: 1.8.129
 
 cloud_provider: none

--- a/files/Makefile.am.extra
+++ b/files/Makefile.am.extra
@@ -348,6 +348,8 @@ libs/googleapis/gens/google/longrunning/operations.grpc.pb.cc \
 libs/googleapis/gens/google/longrunning/operations.pb.cc \
 libs/googleapis/gens/google/cloud/speech/v1p1beta1/cloud_speech.pb.cc \
 libs/googleapis/gens/google/cloud/speech/v1p1beta1/cloud_speech.grpc.pb.cc \
+libs/googleapis/gens/google/cloud/speech/v1p1beta1/resource.pb.cc \
+libs/googleapis/gens/google/cloud/speech/v1p1beta1/resource.grpc.pb.cc \
 libs/googleapis/gens/google/cloud/texttospeech/v1/cloud_tts.pb.cc \
 libs/googleapis/gens/google/cloud/texttospeech/v1/cloud_tts.grpc.pb.cc \
 libs/googleapis/gens/google/logging/type/http_request.grpc.pb.cc  \

--- a/files/Makefile.am.extra
+++ b/files/Makefile.am.extra
@@ -346,8 +346,8 @@ libs/googleapis/gens/google/rpc/error_details.pb.cc \
 libs/googleapis/gens/google/rpc/code.grpc.pb.cc \
 libs/googleapis/gens/google/longrunning/operations.grpc.pb.cc \
 libs/googleapis/gens/google/longrunning/operations.pb.cc \
-libs/googleapis/gens/google/cloud/speech/v1/cloud_speech.pb.cc \
-libs/googleapis/gens/google/cloud/speech/v1/cloud_speech.grpc.pb.cc \
+libs/googleapis/gens/google/cloud/speech/v1p1beta1/cloud_speech.pb.cc \
+libs/googleapis/gens/google/cloud/speech/v1p1beta1/cloud_speech.grpc.pb.cc \
 libs/googleapis/gens/google/cloud/texttospeech/v1/cloud_tts.pb.cc \
 libs/googleapis/gens/google/cloud/texttospeech/v1/cloud_tts.grpc.pb.cc \
 libs/googleapis/gens/google/logging/type/http_request.grpc.pb.cc  \

--- a/files/Makefile.am.extra
+++ b/files/Makefile.am.extra
@@ -346,6 +346,8 @@ libs/googleapis/gens/google/rpc/error_details.pb.cc \
 libs/googleapis/gens/google/rpc/code.grpc.pb.cc \
 libs/googleapis/gens/google/longrunning/operations.grpc.pb.cc \
 libs/googleapis/gens/google/longrunning/operations.pb.cc \
+libs/googleapis/gens/google/cloud/speech/v1/cloud_speech.pb.cc \
+libs/googleapis/gens/google/cloud/speech/v1/cloud_speech.grpc.pb.cc \
 libs/googleapis/gens/google/cloud/speech/v1p1beta1/cloud_speech.pb.cc \
 libs/googleapis/gens/google/cloud/speech/v1p1beta1/cloud_speech.grpc.pb.cc \
 libs/googleapis/gens/google/cloud/speech/v1p1beta1/resource.pb.cc \

--- a/tasks/extra.yml
+++ b/tasks/extra.yml
@@ -92,7 +92,7 @@
 - name: check out googleapis
   git: repo=https://github.com/davehorton/googleapis
        dest={{freeswitch_sources_path}}/libs/googleapis
-       version=dialogflow-v2-support
+       version="{{googleapis_version}}"
        accept_hostkey=yes
        force=yes
 


### PR DESCRIPTION
This change builds a newer version of googleapis and the v1p1beta1 of google speech, along with v1.