### PR TITLE
Patch mod_spandsp_dsp.c to fix missing args in v18_init func

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # path to the FreeSwitch source directory
 freeswitch_sources_path: /usr/local/src/freeswitch/
 
-spandsp_version: master
+spandsp_version: 64f4d2a
 sofia_version: master
 
 # path to the FreeSwitch install directory

--- a/files/mod_spandsp_dsp.c.patch
+++ b/files/mod_spandsp_dsp.c.patch
@@ -1,0 +1,48 @@
+diff --git a/src/mod/applications/mod_spandsp/mod_spandsp_dsp.c b/src/mod/applications/mod_spandsp/mod_spandsp_dsp.c
+index fca74635e8..a0820a6ca4 100644
+--- a/src/mod/applications/mod_spandsp/mod_spandsp_dsp.c
++++ b/src/mod/applications/mod_spandsp/mod_spandsp_dsp.c
+@@ -156,13 +156,13 @@ static int get_v18_mode(switch_core_session_t *session)
+ {
+ 	switch_channel_t *channel = switch_core_session_get_channel(session);
+ 	const char *var;
+-	int r = V18_MODE_5BIT_4545;
++	int r = V18_MODE_WEITBRECHT_5BIT_4545;
+ 
+ 	if ((var = switch_channel_get_variable(channel, "v18_mode"))) {
+ 		if (!strcasecmp(var, "5BIT_45") || !strcasecmp(var, "baudot")) {
+-			r = V18_MODE_5BIT_4545;
++			r = V18_MODE_WEITBRECHT_5BIT_4545;
+ 		} else if (!strcasecmp(var, "5BIT_50")) {
+-			r = V18_MODE_5BIT_50;
++			r = V18_MODE_WEITBRECHT_5BIT_4545;
+ 		} else if (!strcasecmp(var, "DTMF")) {
+ 			r = V18_MODE_DTMF;
+ 		} else if (!strcasecmp(var, "EDT")) {
+@@ -213,7 +213,7 @@ switch_status_t spandsp_tdd_send_session(switch_core_session_t *session, const c
+ 		return SWITCH_STATUS_FALSE;
+ 	}
+ 
+-	tdd_state = v18_init(NULL, TRUE, get_v18_mode(session), V18_AUTOMODING_GLOBAL, put_text_msg, NULL);
++	tdd_state = v18_init(NULL, TRUE, get_v18_mode(session), V18_AUTOMODING_GLOBAL, put_text_msg, NULL, NULL, NULL);
+ 
+ 
+ 	v18_put(tdd_state, text, -1);
+@@ -260,7 +260,7 @@ switch_status_t spandsp_tdd_encode_session(switch_core_session_t *session, const
+ 	}
+ 
+ 	pvt->session = session;
+-	pvt->tdd_state = v18_init(NULL, TRUE, get_v18_mode(session), V18_AUTOMODING_GLOBAL, put_text_msg, NULL);
++	pvt->tdd_state = v18_init(NULL, TRUE, get_v18_mode(session), V18_AUTOMODING_GLOBAL, put_text_msg, NULL, NULL, NULL);
+ 	pvt->head_lead = TDD_LEAD;
+ 
+ 	v18_put(pvt->tdd_state, text, -1);
+@@ -338,7 +338,7 @@ switch_status_t spandsp_tdd_decode_session(switch_core_session_t *session)
+ 	}
+ 
+ 	pvt->session = session;
+-	pvt->tdd_state = v18_init(NULL, FALSE, get_v18_mode(session), V18_AUTOMODING_GLOBAL, put_text_msg, pvt);
++	pvt->tdd_state = v18_init(NULL, FALSE, get_v18_mode(session), V18_AUTOMODING_GLOBAL, put_text_msg, pvt, NULL, NULL);
+ 
+ 	if ((status = switch_core_media_bug_add(session, "spandsp_tdd_decode", NULL,
+ 						tdd_decode_callback, pvt, 0, SMBF_READ_REPLACE | SMBF_NO_PAUSE, &bug)) != SWITCH_STATUS_SUCCESS) {

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,6 +97,14 @@
   loop:
     - {src: "switch_rtp.c.patch", dest: "{{freeswitch_sources_path}}/src/switch_rtp.c"}
 
+- name: patch mod_spandsp_dsp.c to fix missing args in v18_init func
+  patch:
+    remote_src: no
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  loop:
+    - {src: "mod_spandsp_dsp.c.patch", dest: "{{freeswitch_sources_path}}/src/mod/applications/mod_spandsp/mod_spandsp_dsp.c"}
+
 - name: build libwebsockets
   shell: mkdir -p build && cd build && cmake .. && make -j 4 && make install
   args:


### PR DESCRIPTION
I've fixed the compilation error in this repo. Refer to this comment: https://github.com/signalwire/freeswitch/issues/2158#issuecomment-1633877159
